### PR TITLE
feat: io.github.gnuf0rce:netdisk-filesync-plugin

### DIFF
--- a/io/github/gnuf0rce/netdisk-filesync-plugin/package.json
+++ b/io/github/gnuf0rce/netdisk-filesync-plugin/package.json
@@ -1,0 +1,9 @@
+{
+  "type": "plugin-jar",
+  "defaultChannel": "stable",
+  "channels": {
+    "stable": [
+      "1.2.0"
+    ]
+  }
+}

--- a/packages.json
+++ b/packages.json
@@ -149,5 +149,13 @@
             "stable"
         ],
         "website": "https://github.com/gnuf0rce/rss-helper"
+    },
+    "io.github.gnuf0rce:netdisk-filesync-plugin": {
+        "name": "Netdisk FileSync Plugin",
+        "description": "百度云文件同步/备份 插件",
+        "channels": [
+            "stable"
+        ],
+        "website": "https://github.com/gnuf0rce/Netdisk-FileSync-Plugin"
     }
 }


### PR DESCRIPTION
# [Netdisk FileSync Plugin](https://github.com/gnuf0rce/Netdisk-FileSync-Plugin)

> 基于 [Mirai Console](https://github.com/mamoe/mirai-console) 的 文件同步/备份 插件

[![Release](https://img.shields.io/github/v/release/gnuf0rce/Netdisk-FileSync-Plugin)](https://github.com/gnuf0rce/Netdisk-FileSync-Plugin/releases)
![Downloads](https://img.shields.io/github/downloads/gnuf0rce/Netdisk-FileSync-Plugin/total)
[![MiraiForum](https://img.shields.io/badge/post-on%20MiraiForum-yellow)](https://mirai.mamoe.net/topic/765)
![maven-central](https://img.shields.io/maven-central/v/io.github.gnuf0rce/netdisk-filesync-plugin)

本插件可以将接收到的群文件消息同步到百度网盘  
备份的文件在 `/apps/${app_name}/${group_id}/`

本插件也可作为前置插件为其他插件提供百度云上传的API