### PR TITLE
update: mirai-selenium-plugin 1.0.1

### DIFF
--- a/xyz/cssxsh/mirai/mirai-selenium-plugin/package.json
+++ b/xyz/cssxsh/mirai/mirai-selenium-plugin/package.json
@@ -3,7 +3,8 @@
     "defaultChannel": "stable",
     "channels": {
         "stable": [
-            "1.0.0"
+            "1.0.0",
+            "1.0.1"
         ]
     }
 }


### PR DESCRIPTION
1. 支持 Windows 下的 Edge